### PR TITLE
Remove double unlock

### DIFF
--- a/chrome_target.go
+++ b/chrome_target.go
@@ -260,12 +260,15 @@ func (c *ChromeTarget) dispatchResponse(msg []byte) {
 	if r, ok := c.eventDispatcher[f.Method]; ok {
 		c.eventLock.RUnlock()
 		go r(c, msg)
+		return
 
-	} else if c.debugEvents == true {
+	}
+	c.eventLock.RUnlock()
+
+	if c.debugEvents == true {
 		fmt.Printf("\n\nno event recvr bound for: %s\n", f.Method)
 		fmt.Printf("data: %s\n\n", string(msg))
 	}
-	c.eventLock.RUnlock()
 }
 
 // Connects to the tab/process for sending/recv'ing debug events


### PR DESCRIPTION
in order to avoid hangs here.

Note: Also re-ordered imports. Are you using an old version of `goimports`? I can drop this change, if you don't want it.
