### PR TITLE
Longer timeout for windows when connecting to remote instance

### DIFF
--- a/gcd.go
+++ b/gcd.go
@@ -150,6 +150,17 @@ func (c *Gcd) ExitProcess() error {
 	return c.chromeProcess.Kill()
 }
 
+// ConnectToInstance connects to a running chrome instance without starting a local process
+// Host - The host destination.
+// Port - The port to listen on.
+func (c *Gcd) ConnectToInstance(host string, port string) {
+	c.port = port
+	c.addr = fmt.Sprintf("%s:%s", c.host, c.port)
+	c.apiEndpoint = fmt.Sprintf("http://%s/json", c.addr)
+	go c.probeDebugPort()
+	<-c.readyCh
+}
+
 // Gets the primary tabs/processes to work with. Each will have their own references
 // to the underlying API components (such as Page, Debugger, DOM etc).
 func (c *Gcd) GetTargets() ([]*ChromeTarget, error) {
@@ -178,8 +189,15 @@ func (c *Gcd) GetNewTargets(knownIds map[string]struct{}) ([]*ChromeTarget, erro
 		return nil, &GcdDecodingErr{Message: err.Error()}
 	}
 
-	chromeTargets := make([]*ChromeTarget, 0)
+	connectableTargets := make([]*TargetInfo, 0)
 	for _, v := range targets {
+		if v.WebSocketDebuggerUrl != "" {
+			connectableTargets = append(connectableTargets, v)
+		}
+	}
+
+	chromeTargets := make([]*ChromeTarget, 0)
+	for _, v := range connectableTargets {
 		if _, ok := knownIds[v.Id]; !ok {
 			target, err := openChromeTarget(c.addr, v)
 			if err != nil {

--- a/gcd_test.go
+++ b/gcd_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"github.com/wirepair/gcd/gcdapi"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -13,6 +12,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/wirepair/gcd/gcdapi"
 )
 
 var (
@@ -245,6 +246,37 @@ func TestComplexReturn(t *testing.T) {
 	go testTimeoutListener(t, 7, "waiting for page load to get cookies")
 	t.Logf("waiting for loadEventFired")
 	wg.Wait()
+}
+
+func TestConnectToInstance(t *testing.T) {
+	testDefaultStartup(t)
+	defer debugger.ExitProcess()
+
+	doneCh := make(chan struct{})
+
+	go testTimeoutListener(t, 7, "timed out waiting for remote connection")
+	go func() {
+		remoteDebugger := NewChromeDebugger()
+		remoteDebugger.ConnectToInstance(debugger.host, debugger.port)
+
+		_, err := remoteDebugger.NewTab()
+		if err != nil {
+			t.Fatalf("error creating new tab")
+		}
+
+		targets, error := remoteDebugger.GetTargets()
+		if error != nil {
+			t.Fatalf("cannot get targets: %s \n", error)
+		}
+		if len(targets) <= 0 {
+			t.Fatalf("invalid number of targets, got: %d\n", len(targets))
+		}
+		for _, target := range targets {
+			t.Logf("page: %s\n", target.Target.Url)
+		}
+		doneCh <- struct{}{}
+	}()
+	<-doneCh
 }
 
 // UTILITY FUNCTIONS


### PR DESCRIPTION
A new pull request for connecting to a remote chrome instance.

The test TestConnectToInstance is now passing on Windows.
I have tested it with the windows 10 image from https://developer.microsoft.com/en-us/microsoft-edge/tools/vms/ on virtual box with 8 GB memory and 4 cpu's and 80 mb video memory.

To let it pass all tests on the virtual machine I needed to increase the timeout as shown in the diff attached, this isn't in the pull request.
<img width="575" alt="timeout_increments" src="https://cloud.githubusercontent.com/assets/48026/19189883/969d0a44-8c9a-11e6-8e39-7a594369d119.png">