### PR TITLE
Close socket when a successful connection is established.

### DIFF
--- a/gcd.go
+++ b/gcd.go
@@ -267,7 +267,11 @@ func (c *Gcd) probeDebugPort() {
 	for {
 		select {
 		case <-ticker.C:
-			_, err := http.Get(c.apiEndpoint)
+			resp, err := http.Get(c.apiEndpoint)
+			if err != nil {
+				continue
+			}
+			defer resp.Body.Close()
 			if err == nil {
 				c.readyCh <- struct{}{}
 				return

--- a/gcd.go
+++ b/gcd.go
@@ -156,7 +156,6 @@ func (c *Gcd) ExitProcess() error {
 func (c *Gcd) ConnectToInstance(host string, port string) {
 	c.host = host
 	c.port = port
-	c.host = host
 	c.addr = fmt.Sprintf("%s:%s", c.host, c.port)
 	c.apiEndpoint = fmt.Sprintf("http://%s/json", c.addr)
 	go c.probeDebugPort()

--- a/gcd.go
+++ b/gcd.go
@@ -272,10 +272,8 @@ func (c *Gcd) probeDebugPort() {
 				continue
 			}
 			defer resp.Body.Close()
-			if err == nil {
-				c.readyCh <- struct{}{}
-				return
-			}
+			c.readyCh <- struct{}{}
+			return
 		case <-timeoutTicker.C:
 			log.Fatalf("Unable to contact debugger at %s after %d seconds, gave up", c.apiEndpoint, c.timeout)
 		}


### PR DESCRIPTION
I saw a problem (out of network connections) when more than 1000 connections are made after each other to the same Chrome instance (host) from the same Go program. This happens because sockets weren't closed because the body wasn't closed. This PR fixes that specific issue.

I use your library intensively in a product, thank you for making this library.