### PR TITLE
Resolve ConnectToInstance data race

### DIFF
--- a/gcd.go
+++ b/gcd.go
@@ -169,11 +169,10 @@ func (c *Gcd) ConnectToInstance(host string, port string) error {
 	c.addr = fmt.Sprintf("%s:%s", c.host, c.port)
 	c.apiEndpoint = fmt.Sprintf("http://%s/json", c.addr)
 
-	var err error
-	err = nil
-	go func(){
+	var err error = nil
+	go func(err error){
 		err = c.probeDebugPort()
-	}()
+	}(err)
 	<-c.readyCh
 
 	return err


### PR DESCRIPTION
Data race occurred in ConnectToInstance.
I am sorry that it occurred with my correction.
https://github.com/wirepair/gcd/pull/19

```
Failed
==================
WARNING: DATA RACE
Read at 0x00c420378910 by goroutine 7:
  github.com/mfkessai/gae_pdf_service/vendor/github.com/wirepair/gcd.(*Gcd).ConnectToInstance()
      /go/src/github.com/mfkessai/gae_pdf_service/vendor/github.com/wirepair/gcd/gcd.go:179 +0x3e1
```

This time it has not been solved, but there are other occurrences.