### PR TITLE
Messages can be observed

### DIFF
--- a/v2/observer/message_observer.go
+++ b/v2/observer/message_observer.go
@@ -1,0 +1,18 @@
+package observer
+
+var Observe MessageObserver = &IgnoreAllMessagesObserver{}
+
+type MessageObserver interface {
+	Request(ID int64, method string, jsonData []byte, err error)
+	Response(ID int64, method string, jsonData []byte, err error)
+}
+
+type IgnoreAllMessagesObserver struct {}
+
+func (*IgnoreAllMessagesObserver) Request(ID int64, method string, jsonData []byte, err error) {
+	// intentionally blank
+}
+
+func (*IgnoreAllMessagesObserver) Response(ID int64, method string, jsonData []byte, err error) {
+	// intentionally blank
+}


### PR DESCRIPTION
Adds an Observer to the `SendCustomReturn` and `SendDefaultRequest` functions. This allows applications that use the library to log the message however they see fit.

@wirepair If you're happy to accept this change, I'd be interested to know if the messages are also logged for events that we register to (i.e. are there cases where one request can lead to many responses?)

Note that the `Observe` variable in this PR is global. I'm not a fan of this practice, but as the methods that use it are functions (as opposed to methods on an object), this seemed like the easier approach.

