### PR TITLE
Add callback on browser close

### DIFF
--- a/v2/gcd.go
+++ b/v2/gcd.go
@@ -268,9 +268,9 @@ func (c *Gcd) startProcess() error {
 	}()
 
 	var err error
-	go func(err error) {
+	go func() {
 		err = c.probeDebugPort()
-	}(err)
+	}()
 	<-c.readyCh
 
 	return err
@@ -313,9 +313,9 @@ func (c *Gcd) ConnectToInstance(host string, port string) error {
 	c.apiEndpoint = fmt.Sprintf("http://%s/json", c.addr)
 
 	var err error
-	go func(err error) {
+	go func() {
 		err = c.probeDebugPort()
-	}(err)
+	}()
 	<-c.readyCh
 
 	return err


### PR DESCRIPTION
Adds a callback `onChromeExitHandler` to allow users to call a method after chrome has exited. The profile directory has not been deleted allowing for querying of the folder structure.

Also fixes a defect where an error was being lost.