### PR TITLE
SendDefaultRequest should return chrome errors as go errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog (2021)
+- 2.2.1 (July 28th) SendDefaultRequests were not returning ChromeErrorResponses
 - 2.2.0 (July 21st) Dispatching DevTool events via a newly spawned go routine was causing messages to be delivered out of order. This change synchronizes them using an internal channel. Note: If you previously had Subscriptions try to signal each other (via another channel) it may be blocked since all subscriptions are executed under a single go routine now. Upgrade with caution.
 - 2.1.6 (June 9th) Fix go routine leak and add test
 - 2.1.5 (June 8th) Fix race condition on error and endpoint

--- a/v2/chrome_target.go
+++ b/v2/chrome_target.go
@@ -462,6 +462,13 @@ func (c *ChromeTarget) SendDefaultRequest(ctx context.Context, paramRequest *gcd
 		return nil, err
 	}
 
+	// test if error first
+	cerr := &gcdmessage.ChromeErrorResponse{}
+	json.Unmarshal(response.Data, cerr)
+	if cerr != nil && cerr.Error != nil {
+		return nil, &gcdmessage.ChromeRequestErr{Resp: cerr}
+	}
+
 	chromeResponse := &gcdmessage.ChromeResponse{}
 	err = json.Unmarshal(response.Data, chromeResponse)
 

--- a/v2/gcd.go
+++ b/v2/gcd.go
@@ -44,7 +44,7 @@ import (
 
 var json = jsoniter.ConfigCompatibleWithStandardLibrary
 
-var GCDVERSION = "v2.2.0"
+var GCDVERSION = "v2.2.1"
 
 var (
 	ErrNoTabAvailable = errors.New("no available tab found")

--- a/v2/gcd_test.go
+++ b/v2/gcd_test.go
@@ -293,6 +293,21 @@ func TestSimpleReturn(t *testing.T) {
 	}
 }
 
+func TestSimpleReturnReturnsGoError(t *testing.T) {
+	testDefaultStartup(t)
+	defer debugger.ExitProcess()
+
+	target, err := debugger.NewTab()
+	if err != nil {
+		t.Fatalf("error getting new tab: %s\n", err)
+	}
+
+	css := target.CSS
+	if _, err := css.Enable(testCtx); err == nil {
+		t.Fatalf("expected a go error since css.Enable requires DOM.Enable first.")
+	}
+}
+
 // Tests that the ctx canceled doesn't cause the wsconn to get stuck in a loop in windows
 func TestCtxCancel(t *testing.T) {
 	testDefaultStartup(t, WithEventDebugging(), WithEventDebugging())


### PR DESCRIPTION
SendDefaultRequest was not checking for ChromeErrorResponses before attempting to unmarshal as a ChromeResponse.