### PR TITLE
Fix error message

### DIFF
--- a/v2/gcd.go
+++ b/v2/gcd.go
@@ -476,7 +476,7 @@ func (c *Gcd) probeDebugPort(endpoint string) {
 			c.readyChErr <- nil
 			return
 		case <-timeoutTicker.C:
-			c.readyChErr <- fmt.Errorf("Unable to contact debugger at %s after %d seconds, gave up", c.apiEndpoint, c.timeout)
+			c.readyChErr <- fmt.Errorf("Unable to contact debugger at %s after %v, gave up", c.apiEndpoint, c.timeout)
 			return
 		}
 	}

--- a/v2/gcd.go
+++ b/v2/gcd.go
@@ -44,7 +44,7 @@ import (
 
 var json = jsoniter.ConfigCompatibleWithStandardLibrary
 
-var GCDVERSION = "v2.2.1"
+var GCDVERSION = "v2.3.0"
 
 var (
 	ErrNoTabAvailable = errors.New("no available tab found")


### PR DESCRIPTION
Fixes an error that produces a message like: 
`Unable to contact debugger at http://localhost:38479/json after 15000000000 seconds, gave up`.

The suggested fix changes the error to:
`Unable to contact debugger at http://localhost:38479/json after 15s, gave up`.