### PR TITLE
Specify revision to use when updating protocol

### DIFF
--- a/v2/gcdapigen/downloader.go
+++ b/v2/gcdapigen/downloader.go
@@ -28,6 +28,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -38,8 +39,8 @@ const (
 	channel             = "stable"                                  // appears only stable is in github/devtools-protocol.
 	revisionOS          = "win64"                                   // doesn't really matter
 	revisionEndpoint    = "https://omahaproxy.appspot.com/all.json" // get release level info
-	browserProtocolFile = "https://raw.githubusercontent.com/ChromeDevTools/devtools-protocol/master/json/browser_protocol.json"
-	jsProtocolFile      = "https://raw.githubusercontent.com/ChromeDevTools/devtools-protocol/master/json/js_protocol.json"
+	browserProtocolFile = "https://raw.githubusercontent.com/ChromeDevTools/devtools-protocol/%s/json/browser_protocol.json"
+	jsProtocolFile      = "https://raw.githubusercontent.com/ChromeDevTools/devtools-protocol/%s/json/js_protocol.json"
 )
 
 type ChromiumRevision []struct {
@@ -70,12 +71,12 @@ type RevisionInfo struct {
 	JsBranch string
 }
 
-func getApiRevision() *RevisionInfo {
+func getApiRevision(rev string) *RevisionInfo {
 	versionInfo := getRevisionData(channel)
 	if versionInfo == nil {
 		log.Fatalf("Error finding version information from %s", revisionEndpoint)
 	}
-	download(browserProtocolFile, jsProtocolFile)
+	download(fmt.Sprintf(browserProtocolFile, rev), fmt.Sprintf(jsProtocolFile, rev))
 	return versionInfo
 }
 

--- a/v2/gcdapigen/gcdapigen.go
+++ b/v2/gcdapigen/gcdapigen.go
@@ -68,12 +68,14 @@ const CHROME_VERSION = "%s"`
 
 var file string
 var update bool
+var rev string
 var templates *template.Template // for code generation
 var funcMap template.FuncMap     // helper funcs
 var revisionInfo *RevisionInfo
 
 func init() {
 	flag.BoolVar(&update, "update", false, "download and merge js_protocol.json and browser_protocol.json into protocol.json")
+	flag.StringVar(&rev, "rev", "master", "with -update, the revision (branch/tag/commit) from which to download protocol files")
 	flag.StringVar(&file, "file", "protocol.json", "open remote debugger protocol file, if -update the filename to write to.")
 	funcMap := template.FuncMap{
 		"Title":    strings.Title,
@@ -91,7 +93,7 @@ func main() {
 	flag.Parse()
 
 	if update {
-		revisionInfo = getApiRevision()
+		revisionInfo = getApiRevision(rev)
 	}
 
 	protocolData := openFile()


### PR DESCRIPTION
This MR adds the option to specify a revision to use when downloading protocol files. This is necessary because Chrome DevTools does not track the stable channel, unlike the version information that is embedded into gcd. For example, currently Chrome DevTools master is on 112, but the stable channel is on 111. So if you run `gcdapigen -update`, you end up with the protocol file and generated code for 112, but the `CHROME_VERSION` in `version.go` is 111.

Usage:
```
cd v2/gcdapigen
go build
./gcdapigen -update -rev=v0.0.1119769
```
