### PR TITLE
Fix calls with two dimension array return types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
+# Changelog (2024)
+- 2.3.4 (Mar 18)
+  - Fix return types for calls that return two-dimensional arrays 
+- 2.3.3 (Jan 31)
+  - Improve JSON performance
+
 # Changelog (2023)
+- 2.3.2 (Dec 6)
+  - Reorder and initialize missing DevTools domains 
 - 2.3.1 (May 30) 
   - Applied patch from @camswords to expose dev tools version
   - Updates to chrome 112.0.5615.138

--- a/v2/gcdapi/dom.go
+++ b/v2/gcdapi/dom.go
@@ -578,7 +578,7 @@ type DOMGetContentQuadsParams struct {
 
 // GetContentQuadsWithParams - Returns quads that describe node position on the page. This method might return multiple quads for inline nodes.
 // Returns -  quads - Quads that describe node layout relative to viewport.
-func (c *DOM) GetContentQuadsWithParams(ctx context.Context, v *DOMGetContentQuadsParams) ([]float64, error) {
+func (c *DOM) GetContentQuadsWithParams(ctx context.Context, v *DOMGetContentQuadsParams) ([][]float64, error) {
 	resp, err := c.target.SendCustomReturn(ctx, &gcdmessage.ParamRequest{Id: c.target.GetId(), Method: "DOM.getContentQuads", Params: v})
 	if err != nil {
 		return nil, err
@@ -587,7 +587,7 @@ func (c *DOM) GetContentQuadsWithParams(ctx context.Context, v *DOMGetContentQua
 	var chromeData struct {
 		gcdmessage.ChromeErrorResponse
 		Result struct {
-			Quads []float64
+			Quads [][]float64
 		}
 	}
 
@@ -611,7 +611,7 @@ func (c *DOM) GetContentQuadsWithParams(ctx context.Context, v *DOMGetContentQua
 // backendNodeId - Identifier of the backend node.
 // objectId - JavaScript object id of the node wrapper.
 // Returns -  quads - Quads that describe node layout relative to viewport.
-func (c *DOM) GetContentQuads(ctx context.Context, nodeId int, backendNodeId int, objectId string) ([]float64, error) {
+func (c *DOM) GetContentQuads(ctx context.Context, nodeId int, backendNodeId int, objectId string) ([][]float64, error) {
 	var v DOMGetContentQuadsParams
 	v.NodeId = nodeId
 	v.BackendNodeId = backendNodeId

--- a/v2/gcdapi/domsnapshot.go
+++ b/v2/gcdapi/domsnapshot.go
@@ -114,7 +114,7 @@ type DOMSnapshotNodeTreeSnapshot struct {
 	NodeName             []int                       `json:"nodeName,omitempty"`             // `Node`'s nodeName.
 	NodeValue            []int                       `json:"nodeValue,omitempty"`            // `Node`'s nodeValue.
 	BackendNodeId        []int                       `json:"backendNodeId,omitempty"`        // `Node`'s id, corresponds to DOM.Node.backendNodeId.
-	Attributes           []int                       `json:"attributes,omitempty"`           // Attributes of an `Element` node. Flatten name, value pairs.
+	Attributes           [][]int                     `json:"attributes,omitempty"`           // Attributes of an `Element` node. Flatten name, value pairs.
 	TextValue            *DOMSnapshotRareStringData  `json:"textValue,omitempty"`            // Only set for textarea elements, contains the text value.
 	InputValue           *DOMSnapshotRareStringData  `json:"inputValue,omitempty"`           // Only set for input elements, contains the input's associated text value.
 	InputChecked         *DOMSnapshotRareBooleanData `json:"inputChecked,omitempty"`         // Only set for radio and checkbox input elements, indicates if the element has been checked
@@ -130,24 +130,24 @@ type DOMSnapshotNodeTreeSnapshot struct {
 // Table of details of an element in the DOM tree with a LayoutObject.
 type DOMSnapshotLayoutTreeSnapshot struct {
 	NodeIndex               []int                       `json:"nodeIndex"`                         // Index of the corresponding node in the `NodeTreeSnapshot` array returned by `captureSnapshot`.
-	Styles                  []int                       `json:"styles"`                            // Array of indexes specifying computed style strings, filtered according to the `computedStyles` parameter passed to `captureSnapshot`.
-	Bounds                  []float64                   `json:"bounds"`                            // The absolute position bounding box.
+	Styles                  [][]int                     `json:"styles"`                            // Array of indexes specifying computed style strings, filtered according to the `computedStyles` parameter passed to `captureSnapshot`.
+	Bounds                  [][]float64                 `json:"bounds"`                            // The absolute position bounding box.
 	Text                    []int                       `json:"text"`                              // Contents of the LayoutText, if any.
 	StackingContexts        *DOMSnapshotRareBooleanData `json:"stackingContexts"`                  // Stacking context information.
 	PaintOrders             []int                       `json:"paintOrders,omitempty"`             // Global paint order index, which is determined by the stacking order of the nodes. Nodes that are painted together will have the same index. Only provided if includePaintOrder in captureSnapshot was true.
-	OffsetRects             []float64                   `json:"offsetRects,omitempty"`             // The offset rect of nodes. Only available when includeDOMRects is set to true
-	ScrollRects             []float64                   `json:"scrollRects,omitempty"`             // The scroll rect of nodes. Only available when includeDOMRects is set to true
-	ClientRects             []float64                   `json:"clientRects,omitempty"`             // The client rect of nodes. Only available when includeDOMRects is set to true
+	OffsetRects             [][]float64                 `json:"offsetRects,omitempty"`             // The offset rect of nodes. Only available when includeDOMRects is set to true
+	ScrollRects             [][]float64                 `json:"scrollRects,omitempty"`             // The scroll rect of nodes. Only available when includeDOMRects is set to true
+	ClientRects             [][]float64                 `json:"clientRects,omitempty"`             // The client rect of nodes. Only available when includeDOMRects is set to true
 	BlendedBackgroundColors []int                       `json:"blendedBackgroundColors,omitempty"` // The list of background colors that are blended with colors of overlapping elements.
 	TextColorOpacities      []float64                   `json:"textColorOpacities,omitempty"`      // The list of computed text opacities.
 }
 
 // Table of details of the post layout rendered text positions. The exact layout should not be regarded as stable and may change between versions.
 type DOMSnapshotTextBoxSnapshot struct {
-	LayoutIndex []int     `json:"layoutIndex"` // Index of the layout tree node that owns this box collection.
-	Bounds      []float64 `json:"bounds"`      // The absolute position bounding box.
-	Start       []int     `json:"start"`       // The starting index in characters, for this post layout textbox substring. Characters that would be represented as a surrogate pair in UTF-16 have length 2.
-	Length      []int     `json:"length"`      // The number of characters in this post layout textbox substring. Characters that would be represented as a surrogate pair in UTF-16 have length 2.
+	LayoutIndex []int       `json:"layoutIndex"` // Index of the layout tree node that owns this box collection.
+	Bounds      [][]float64 `json:"bounds"`      // The absolute position bounding box.
+	Start       []int       `json:"start"`       // The starting index in characters, for this post layout textbox substring. Characters that would be represented as a surrogate pair in UTF-16 have length 2.
+	Length      []int       `json:"length"`      // The number of characters in this post layout textbox substring. Characters that would be represented as a surrogate pair in UTF-16 have length 2.
 }
 
 type DOMSnapshot struct {

--- a/v2/gcdapi/domstorage.go
+++ b/v2/gcdapi/domstorage.go
@@ -94,7 +94,7 @@ type DOMStorageGetDOMStorageItemsParams struct {
 
 // GetDOMStorageItemsWithParams -
 // Returns -  entries -
-func (c *DOMStorage) GetDOMStorageItemsWithParams(ctx context.Context, v *DOMStorageGetDOMStorageItemsParams) ([]string, error) {
+func (c *DOMStorage) GetDOMStorageItemsWithParams(ctx context.Context, v *DOMStorageGetDOMStorageItemsParams) ([][]string, error) {
 	resp, err := c.target.SendCustomReturn(ctx, &gcdmessage.ParamRequest{Id: c.target.GetId(), Method: "DOMStorage.getDOMStorageItems", Params: v})
 	if err != nil {
 		return nil, err
@@ -103,7 +103,7 @@ func (c *DOMStorage) GetDOMStorageItemsWithParams(ctx context.Context, v *DOMSto
 	var chromeData struct {
 		gcdmessage.ChromeErrorResponse
 		Result struct {
-			Entries []string
+			Entries [][]string
 		}
 	}
 
@@ -125,7 +125,7 @@ func (c *DOMStorage) GetDOMStorageItemsWithParams(ctx context.Context, v *DOMSto
 // GetDOMStorageItems -
 // storageId -
 // Returns -  entries -
-func (c *DOMStorage) GetDOMStorageItems(ctx context.Context, storageId *DOMStorageStorageId) ([]string, error) {
+func (c *DOMStorage) GetDOMStorageItems(ctx context.Context, storageId *DOMStorageStorageId) ([][]string, error) {
 	var v DOMStorageGetDOMStorageItemsParams
 	v.StorageId = storageId
 	return c.GetDOMStorageItemsWithParams(ctx, &v)

--- a/v2/gcdapi/gcdapi_test.go
+++ b/v2/gcdapi/gcdapi_test.go
@@ -1,0 +1,53 @@
+package gcdapi_test
+
+import (
+	"github.com/wirepair/gcd/v2/gcdapi"
+	"reflect"
+	"testing"
+)
+
+func TestReturnValuesAreGeneratedProperlyForCommands(t *testing.T) {
+	tests := []struct {
+		name               string
+		function           interface{}
+		expectedReturnType string
+	}{
+		{
+			name:               "a base type",
+			function:           (&gcdapi.DOM{}).GetOuterHTML,
+			expectedReturnType: "string",
+		},
+		{
+			name:               "a reference to a complex type",
+			function:           (&gcdapi.DOM{}).DescribeNode,
+			expectedReturnType: "*gcdapi.DOMNode",
+		},
+		{
+			name:               "an array of a base type",
+			function:           (&gcdapi.DOM{}).CollectClassNamesFromSubtree,
+			expectedReturnType: "[]string",
+		},
+		{
+			name:               "an array to a reference type that references a base type",
+			function:           (&gcdapi.DOM{}).GetNodesForSubtreeByStyle,
+			expectedReturnType: "[]int",
+		},
+		{
+			name:               "an array to a reference type that references an array of a base type",
+			function:           (&gcdapi.DOMStorage{}).GetDOMStorageItems,
+			expectedReturnType: "[][]string",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fnType := reflect.TypeOf(test.function)
+			returnType := fnType.Out(0).String()
+
+			if test.expectedReturnType != returnType {
+				t.Logf("test failed, expected %v, got %v", test.expectedReturnType, returnType)
+				t.Fail()
+			}
+		})
+	}
+}

--- a/v2/gcdapi/layertree.go
+++ b/v2/gcdapi/layertree.go
@@ -230,7 +230,7 @@ type LayerTreeProfileSnapshotParams struct {
 
 // ProfileSnapshotWithParams -
 // Returns -  timings - The array of paint profiles, one per run.
-func (c *LayerTree) ProfileSnapshotWithParams(ctx context.Context, v *LayerTreeProfileSnapshotParams) ([]float64, error) {
+func (c *LayerTree) ProfileSnapshotWithParams(ctx context.Context, v *LayerTreeProfileSnapshotParams) ([][]float64, error) {
 	resp, err := c.target.SendCustomReturn(ctx, &gcdmessage.ParamRequest{Id: c.target.GetId(), Method: "LayerTree.profileSnapshot", Params: v})
 	if err != nil {
 		return nil, err
@@ -239,7 +239,7 @@ func (c *LayerTree) ProfileSnapshotWithParams(ctx context.Context, v *LayerTreeP
 	var chromeData struct {
 		gcdmessage.ChromeErrorResponse
 		Result struct {
-			Timings []float64
+			Timings [][]float64
 		}
 	}
 
@@ -264,7 +264,7 @@ func (c *LayerTree) ProfileSnapshotWithParams(ctx context.Context, v *LayerTreeP
 // minDuration - The minimum duration (in seconds) to replay the snapshot.
 // clipRect - The clip rectangle to apply when replaying the snapshot.
 // Returns -  timings - The array of paint profiles, one per run.
-func (c *LayerTree) ProfileSnapshot(ctx context.Context, snapshotId string, minRepeatCount int, minDuration float64, clipRect *DOMRect) ([]float64, error) {
+func (c *LayerTree) ProfileSnapshot(ctx context.Context, snapshotId string, minRepeatCount int, minDuration float64, clipRect *DOMRect) ([][]float64, error) {
 	var v LayerTreeProfileSnapshotParams
 	v.SnapshotId = snapshotId
 	v.MinRepeatCount = minRepeatCount

--- a/v2/gcdapigen/domain.go
+++ b/v2/gcdapigen/domain.go
@@ -261,10 +261,17 @@ func (d *Domain) resolveReference(prop PropSetter) bool {
 		}
 		prop.SetIsRef(true)
 	}
-	// set the type as being an array of whatever type it references
+
 	if ref.IsArrayRef {
+		if prop.GetIsTypeArray() {
+			// if the outer object is already an array, we have a double array, so make type a slice
+			prop.SetGoType("[]" + prop.GetGoType())
+		}
+
+		// set the type as being an array of whatever type it references
 		prop.SetIsTypeArray(true)
 	}
+
 	// add enum possible values to description
 	if ref.EnumDescription != "" {
 		prop.SetDescription(prop.GetDescription() + ref.EnumDescription)

--- a/v2/gcdapigen/return.go
+++ b/v2/gcdapigen/return.go
@@ -78,6 +78,10 @@ func (r *Return) SetIsTypeArray(isTypeArray bool) {
 	r.IsTypeArray = true
 }
 
+func (r *Return) GetIsTypeArray() bool {
+	return r.IsTypeArray
+}
+
 func (r *Return) GetEnumVals() string {
 	return r.EnumVals
 }

--- a/v2/gcdapigen/type_properties.go
+++ b/v2/gcdapigen/type_properties.go
@@ -78,6 +78,10 @@ func (p *TypeProperties) SetIsTypeArray(isTypeArray bool) {
 	p.IsTypeArray = true
 }
 
+func (p *TypeProperties) GetIsTypeArray() bool {
+	return p.IsTypeArray
+}
+
 func (p *TypeProperties) GetRef() string {
 	return p.Ref
 }

--- a/v2/gcdapigen/utils.go
+++ b/v2/gcdapigen/utils.go
@@ -36,6 +36,7 @@ type PropSetter interface {
 	GetEnumVals() string
 	SetGoType(goType string)
 	SetIsTypeArray(isTypeArray bool)
+	GetIsTypeArray() bool
 	GetDescription() string
 	SetDescription(description string)
 	SetIsRef(isRef bool)
@@ -163,7 +164,7 @@ func isSubType(protoProp *ProtoProperty) bool {
 func isPointerType(props PropSetter) bool {
 	goType := props.GetGoType()
 	switch goType {
-	case "int", "string", "bool", "float64", "map[string]interface{}", "interface{}":
+	case "int", "string", "bool", "float64", "map[string]interface{}", "interface{}", "[]int", "[]string", "[]bool", "[]float64", "[]map[string]interface{}", "[]interface{}":
 		return false
 	}
 	return true


### PR DESCRIPTION
## What does this PR do?

Fixes generation of the API to ensure that commands that return two-dimensional arrays return the correct value. Examples include `DOM.GetContentQuads` and `DOMStorage.GetDOMStorageItems`.

The CHANGELOG has been updated to include missed previous releases.