### PR TITLE
Add logging for DevTools websocket message handling

### DIFF
--- a/v2/chrome_target.go
+++ b/v2/chrome_target.go
@@ -325,7 +325,7 @@ func (c *ChromeTarget) dispatchResponse(msg []byte) {
 	if r, ok := c.replyDispatcher[f.Id]; ok {
 		delete(c.replyDispatcher, f.Id)
 		c.replyLock.Unlock()
-		c.logDebug("dispatching response id:", f.Id)
+		c.logDebug(f.Id, " dispatching reply")
 		go c.dispatchWithTimeout(r, f.Id, msg)
 		return
 	}

--- a/v2/chrome_target.go
+++ b/v2/chrome_target.go
@@ -385,7 +385,7 @@ func (c *ChromeTarget) dispatchWithTimeout(r chan<- *gcdmessage.Message, id int6
 	case r <- &gcdmessage.Message{Id: id, Data: msg}:
 		timeout.Stop()
 	case <-timeout.C:
-		c.logDebug("timed out dispatching request id: ", id, " of msg: ", msg)
+		c.logger.Println("timed out dispatching request id: ", id, " of msg: ", msg)
 		close(r)
 		return
 	}

--- a/v2/chrome_target.go
+++ b/v2/chrome_target.go
@@ -365,7 +365,7 @@ func (c *ChromeTarget) dispatchEvents() {
 		case <-c.ctx.Done():
 			return
 		case m := <-c.eventCh:
-			c.logDebug("dispatching", m.Method, "event: ", string(m.Msg))
+			c.logDebug("dispatching ", m.Method, "event: ", string(m.Msg))
 			c.eventLock.Lock()
 			cb, ok := c.eventDispatcher[m.Method]
 			c.eventLock.Unlock()


### PR DESCRIPTION
These are changes that we made locally to aid in a recent troubleshooting effort. Mainly this adds logging when enqueuing events received from the DevTools websocket to be processed by `dispatchEvents`:

1. Log when the event queue is full
1. Debug log when a message is about to be enqueued. This identifies when the event was received from DevTools, which is helpful in cases when the processing is delayed (because the queue is full).
1. Debug log when a message has been enqueued. In cases where the queue is full, this helps quantify the delay.

